### PR TITLE
German Translation updates

### DIFF
--- a/ejectify/de.lproj/Localizable.strings
+++ b/ejectify/de.lproj/Localizable.strings
@@ -6,14 +6,14 @@
   
 */
 
-"No volumes" = "Kein Volumes";
+"No volumes" = "Keine Volumes";
 "Volumes" = "Volumes";
 "Preferences" = "Einstellungen";
 "Launch at login" = "Beim Login starten";
-"Unmount when" = "Deaktivieren wenn";
-"Screensaver started" = "Bildschirmschoner gestartet";
-"Screen is locked" = "Bildschirm ist gesperrt";
-"Display turned off" = "Monitor ist ausgeschaltet";
-"System starts sleeping" = "Ruhezustand wird aktiviert";
+"Unmount when" = "Auswerfen, sobald";
+"Screensaver started" = "Bildschirmschoner startet";
+"Screen is locked" = "Bildschirm gesperrt wird";
+"Display turned off" = "Ruhezustand für Monitor aktiviert wird";
+"System starts sleeping" = "Ruhezustand für Computer aktiviert wird";
 "About Ejectify" = "Über Ejectify";
 "Quit Ejectify" = "Ejectify beenden";


### PR DESCRIPTION
No Volumes - suggests plural, thus "Keine" rather than "Kein"
Unmount is translated aus Auswerfen bei macOS

To make the the setting "unmount when" more readable in German, I used grammer that would always make it a full sentence, i.e.

Unmount when screesaver started
=
Auswerfen, sobald Bildschirmschoner startet

Two screenshots from macOS Catalina to compare language usage are incuded

![Bildschirmfoto 2021-01-13 um 18 04 36](https://user-images.githubusercontent.com/43129918/104484717-e5f8b000-55c9-11eb-91ce-490d44a74644.png)

![Bildschirmfoto 2021-01-13 um 18 04 45](https://user-images.githubusercontent.com/43129918/104484709-e3965600-55c9-11eb-9f4a-2b8db852982b.png)
