### PR TITLE
Update of French translation

### DIFF
--- a/ejectify/fr.lproj/Localizable.strings
+++ b/ejectify/fr.lproj/Localizable.strings
@@ -9,9 +9,9 @@
 "No volumes" = "Pas de volumes";
 "Volumes" = "Volumes";
 "Preferences" = "Préférences";
-"Launch at login" = "Lancer à la connexion";
-"Unmount when" = "Démonter quand";
-"Screensaver started" = "L'économiseur d'écran démarré";
+"Launch at login" = "Lancer au démarrage";
+"Unmount when" = "Éjecter dès que";
+"Screensaver started" = "L'économiseur d'écran démarre";
 "Screen is locked" = "L'écran est verrouillé";
 "Display turned off" = "L'écran est éteint";
 "System starts sleeping" = "Le système est suspendu";


### PR DESCRIPTION
I've updated the "Unmount when" like the German update #13 suggested to make the whole string a full sentence in French.

I've updated the "Launch at login" to reflect what I've found on macOS and in others apps they seems to use both "connexion" and "démarrage" but I prefer "démarrage" because it is more clear in my opinion. This is really subjective. 

Lastly, I've updated "Screensaver started" for a small typo ;-)

I'm open to any discussion regarding this PR.