### PR TITLE
Add Unmount All button

### DIFF
--- a/ejectify/View/StatusBarMenu.swift
+++ b/ejectify/View/StatusBarMenu.swift
@@ -38,12 +38,20 @@ class StatusBarMenu: NSMenu {
     
     private func updateMenu() {
         self.removeAllItems()
+        buildUnmountAllMenu()
         buildVolumesMenu()
         buildOptionsMenu()
         buildAppMenu()
     }
     
+    private func buildUnmountAllMenu() {
+        let unmountAllItem = NSMenuItem(title: "Unmount All".localized, action: #selector(unmountAllClicked(menuItem:)), keyEquivalent: "")
+        unmountAllItem.target = volumes.count > 0 ? self : nil
+        addItem(unmountAllItem)
+    }
+
     private func buildVolumesMenu() {
+        addItem(NSMenuItem.separator())
         
         // Title
         let title = volumes.count == 0 ? "No volumes".localized : "Volumes".localized
@@ -124,7 +132,15 @@ class StatusBarMenu: NSMenu {
         quitItem.target = self
         addItem(quitItem)
     }
-    
+
+    @objc private func unmountAllClicked(menuItem: NSMenuItem) {
+        volumes.filter { $0.enabled }
+            .forEach { (volume) in
+                volume.unmount()
+            }
+        updateMenu()
+    }
+
     @objc private func volumeClicked(menuItem: NSMenuItem) {
         guard let volume = menuItem.representedObject as? Volume else {
             return


### PR DESCRIPTION
Part of what #20 asks for. Not sure how you would like to indicate progress, in this PR it silently unmounts all in the background.

I have a change in https://github.com/ropc/ejectify-macos/tree/main that changes the icon while the unmount is in progress, which can be added to this PR if that works.

Also, this may need localizations.