### PR TITLE
Clarify privileged helper log message

### DIFF
--- a/ejectify/Helper/VolumeOperationRouter.swift
+++ b/ejectify/Helper/VolumeOperationRouter.swift
@@ -337,7 +337,7 @@ final class VolumeOperationRouter: @unchecked Sendable {
         withStateLock {
             helperConnection = connection
         }
-        logger.info("Priviledged helper XPC connection established")
+        logger.info("Privileged helper XPC client connection set up")
         return connection
     }
 


### PR DESCRIPTION
## Summary
- update the helper router log entry to state that the privileged helper XPC client connection is set up, matching the observed behavior

## Testing
- Not run (not requested)