### PR TITLE
Add a global shortcut for unmounting all volumes

### DIFF
--- a/Ejectify.xcodeproj/project.pbxproj
+++ b/Ejectify.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		B8DFADB6256CF511009E9296 /* Volume.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8DFADB2256CF511009E9296 /* Volume.swift */; };
 		B8DFADB7256CF511009E9296 /* StatusBarMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8DFADB4256CF511009E9296 /* StatusBarMenu.swift */; };
 		B8DFADBA256D0565009E9296 /* ActivityController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8DFADB9256D0565009E9296 /* ActivityController.swift */; };
+		D3F100A12FA2000100B0E001 /* GlobalHotKeyController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F100A22FA2000100B0E001 /* GlobalHotKeyController.swift */; };
 		C0A100000000000000000001 /* PrivilegedDiskServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A100000000000000000011 /* PrivilegedDiskServiceProtocol.swift */; };
 		C0A100000000000000000002 /* VolumeOperationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A100000000000000000012 /* VolumeOperationRouter.swift */; };
 		C0A100000000000000000003 /* PrivilegedDiskServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A100000000000000000011 /* PrivilegedDiskServiceProtocol.swift */; };
@@ -122,6 +123,7 @@
 		B8DFADB2256CF511009E9296 /* Volume.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Volume.swift; sourceTree = "<group>"; };
 		B8DFADB4256CF511009E9296 /* StatusBarMenu.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusBarMenu.swift; sourceTree = "<group>"; };
 		B8DFADB9256D0565009E9296 /* ActivityController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityController.swift; sourceTree = "<group>"; };
+		D3F100A22FA2000100B0E001 /* GlobalHotKeyController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalHotKeyController.swift; sourceTree = "<group>"; };
 		D2A100A22F9B100100A0C001 /* UpdateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateController.swift; sourceTree = "<group>"; };
 		C0A100000000000000000011 /* PrivilegedDiskServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivilegedDiskServiceProtocol.swift; sourceTree = "<group>"; };
 		C0A100000000000000000012 /* VolumeOperationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeOperationRouter.swift; sourceTree = "<group>"; };
@@ -211,6 +213,7 @@
 			isa = PBXGroup;
 			children = (
 				B8DFADB9256D0565009E9296 /* ActivityController.swift */,
+				D3F100A22FA2000100B0E001 /* GlobalHotKeyController.swift */,
 				D1E700A62F8A000100C0D001 /* OnboardingWindowController.swift */,
 				D1E700A22F8A000100C0D001 /* SystemSleepPowerObserver.swift */,
 				D2A100A22F9B100100A0C001 /* UpdateController.swift */,
@@ -427,6 +430,7 @@
 				B8DFADB7256CF511009E9296 /* StatusBarMenu.swift in Sources */,
 				B8DFADB6256CF511009E9296 /* Volume.swift in Sources */,
 				B8AF59E92569569A003481A8 /* AppDelegate.swift in Sources */,
+				D3F100A12FA2000100B0E001 /* GlobalHotKeyController.swift in Sources */,
 				D1E700A52F8A000100C0D001 /* OnboardingWindowController.swift in Sources */,
 				D1E700AB2F8A000100C0D001 /* StopNotificationView.swift in Sources */,
 				B8DFADBA256D0565009E9296 /* ActivityController.swift in Sources */,

--- a/Ejectify/AppDelegate.swift
+++ b/Ejectify/AppDelegate.swift
@@ -6,11 +6,15 @@
 //
 
 import Cocoa
+import OSLog
 
 @MainActor
 
 /// Coordinates app startup and wires core menu/activity controllers.
 final class AppDelegate: NSObject, NSApplicationDelegate {
+
+    /// Logger used for app lifecycle events and shared menu actions.
+    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "nl.nielsmouthaan.Ejectify", category: "AppDelegate")
 
     /// Shared delegate instance exposed for app-wide coordination.
     static let shared = NSApplication.shared.delegate as! AppDelegate
@@ -21,11 +25,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Owns event observation and mount/unmount orchestration.
     var activityController: ActivityController?
 
+    /// Owns global hotkey registration and dispatch for manual unmount-all.
+    private var globalHotKeyController: GlobalHotKeyController?
+
     /// Owns Sparkle updater lifecycle and manual update actions.
     private var updateController: UpdateController?
 
     /// Owns the onboarding window lifecycle while guidance is presented.
     private var onboardingWindowController: OnboardingWindowController?
+
+    /// Returns whether the global unmount-all hotkey is currently registered.
+    var isUnmountAllHotKeyRegistered: Bool {
+        globalHotKeyController?.isRegistered ?? false
+    }
 
     /// Bootstraps routing mode, applies one-time first-run setup, and initializes primary app controllers.
     func applicationDidFinishLaunching(_ aNotification: Notification) {
@@ -39,6 +51,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             VolumeOperationRouter.shared.requestPrivilegedExecutionMode()
         }
 
+        globalHotKeyController = GlobalHotKeyController { [weak self] in
+            self?.performManualUnmountAll()
+        }
         statusBar = StatusBar()
         activityController = ActivityController()
         let updateController = UpdateController()
@@ -53,6 +68,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Starts a user-initiated Sparkle update check.
     func checkForUpdates() {
         updateController?.checkForUpdates()
+    }
+
+    /// Unmounts all enabled volumes in response to a user-initiated action.
+    func performManualUnmountAll() {
+        let enabledVolumes = Volume.mountedVolumes().filter(\.enabled)
+        logger.info("Manual unmount-all triggered: \(enabledVolumes.count, privacy: .public) enabled volumes")
+
+        for volume in enabledVolumes {
+            VolumeOperationRouter.shared.unmount(
+                volumeUUID: volume.id as NSUUID,
+                volumeName: volume.name,
+                bsdName: volume.bsdName,
+                force: Preference.forceUnmount
+            ) { _ in }
+        }
+
+        statusBar?.refreshMenu()
     }
 
     /// Sends a best-effort helper shutdown request when the app is quitting.

--- a/Ejectify/Controller/GlobalHotKeyController.swift
+++ b/Ejectify/Controller/GlobalHotKeyController.swift
@@ -1,0 +1,178 @@
+//
+//  GlobalHotKeyController.swift
+//  Ejectify
+//
+//  Created by Codex on 17/03/2026.
+//
+
+import Carbon
+import Foundation
+import OSLog
+
+/// Registers and handles the app-wide keyboard shortcut for manual unmount-all.
+final class GlobalHotKeyController {
+
+    /// Carbon signature used to identify Ejectify's hotkey events.
+    private static let hotKeySignature: OSType = 0x456A484B // ASCII for "EjHK" (Ejectify hotkey)
+
+    /// Carbon identifier used to distinguish the unmount-all hotkey from other hotkeys.
+    private static let hotKeyID: UInt32 = 1
+
+    /// Event specification describing the hotkey-pressed callback this controller listens for.
+    private static let hotKeyPressedEvent = EventTypeSpec(
+        eventClass: OSType(kEventClassKeyboard),
+        eventKind: UInt32(kEventHotKeyPressed)
+    )
+
+    /// C callback that forwards Carbon hotkey events back into the Swift controller instance.
+    private static let hotKeyHandler: EventHandlerUPP = { _, eventRef, userData in
+        guard let eventRef, let userData else {
+            return noErr
+        }
+
+        let controller = Unmanaged<GlobalHotKeyController>.fromOpaque(userData).takeUnretainedValue()
+        controller.handleHotKeyPressed(eventRef)
+        return noErr
+    }
+
+    /// Logger used for registration and trigger diagnostics.
+    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "nl.nielsmouthaan.Ejectify", category: "GlobalHotKeyController")
+
+    /// Action invoked when the registered global hotkey is pressed.
+    private let onUnmountAll: @MainActor () -> Void
+
+    /// Registered Carbon event handler reference for hotkey press callbacks.
+    private var eventHandlerRef: EventHandlerRef?
+
+    /// Registered Carbon hotkey reference while the shortcut is active.
+    private var eventHotKeyRef: EventHotKeyRef?
+
+    /// Returns whether the global hotkey registration is currently active.
+    private(set) var isRegistered = false
+
+    /// Creates the controller, installs its event handler, and attempts hotkey registration.
+    init(onUnmountAll: @escaping @MainActor () -> Void) {
+        self.onUnmountAll = onUnmountAll
+        installHotKeyHandlerIfNeeded()
+        registerHotKey()
+    }
+
+    /// Unregisters the hotkey and removes the Carbon event handler.
+    deinit {
+        unregisterHotKey()
+        removeHotKeyHandler()
+    }
+
+    /// Installs the Carbon event handler used to receive global hotkey press events.
+    private func installHotKeyHandlerIfNeeded() {
+        guard eventHandlerRef == nil else {
+            return
+        }
+
+        var eventHandlerRef: EventHandlerRef?
+        var hotKeyPressedEvent = Self.hotKeyPressedEvent
+        let status = InstallEventHandler(
+            GetApplicationEventTarget(),
+            Self.hotKeyHandler,
+            1,
+            &hotKeyPressedEvent,
+            Unmanaged.passUnretained(self).toOpaque(),
+            &eventHandlerRef
+        )
+
+        guard status == noErr, let eventHandlerRef else {
+            logger.error("Failed to install global hotkey event handler: status=\(status, privacy: .public)")
+            return
+        }
+
+        self.eventHandlerRef = eventHandlerRef
+    }
+
+    /// Attempts to register the fixed global `Control` + `Command` + `U` hotkey.
+    private func registerHotKey() {
+        guard eventHotKeyRef == nil else {
+            return
+        }
+
+        var hotKeyRef: EventHotKeyRef?
+        let hotKeyID = EventHotKeyID(signature: Self.hotKeySignature, id: Self.hotKeyID)
+        let status = RegisterEventHotKey(
+            UInt32(kVK_ANSI_U),
+            UInt32(controlKey | cmdKey),
+            hotKeyID,
+            GetApplicationEventTarget(),
+            0,
+            &hotKeyRef
+        )
+
+        guard status == noErr, let hotKeyRef else {
+            isRegistered = false
+            logger.error("Failed to register global unmount-all hotkey (Control-Command-U): status=\(status, privacy: .public)")
+            return
+        }
+
+        eventHotKeyRef = hotKeyRef
+        isRegistered = true
+        logger.info("Registered global unmount-all hotkey: Control-Command-U")
+    }
+
+    /// Unregisters the Carbon hotkey if it is currently active.
+    private func unregisterHotKey() {
+        guard let eventHotKeyRef else {
+            isRegistered = false
+            return
+        }
+
+        let status = UnregisterEventHotKey(eventHotKeyRef)
+        if status == noErr {
+            logger.info("Unregistered global unmount-all hotkey")
+        } else {
+            logger.error("Failed to unregister global unmount-all hotkey: status=\(status, privacy: .public)")
+        }
+
+        self.eventHotKeyRef = nil
+        isRegistered = false
+    }
+
+    /// Removes the Carbon event handler when the controller is torn down.
+    private func removeHotKeyHandler() {
+        guard let eventHandlerRef else {
+            return
+        }
+
+        let status = RemoveEventHandler(eventHandlerRef)
+        if status != noErr {
+            logger.error("Failed to remove global hotkey event handler: status=\(status, privacy: .public)")
+        }
+
+        self.eventHandlerRef = nil
+    }
+
+    /// Handles an incoming Carbon hotkey event and dispatches the shared unmount action.
+    private func handleHotKeyPressed(_ eventRef: EventRef) {
+        var hotKeyID = EventHotKeyID()
+        let status = GetEventParameter(
+            eventRef,
+            EventParamName(kEventParamDirectObject),
+            EventParamType(typeEventHotKeyID),
+            nil,
+            MemoryLayout<EventHotKeyID>.size,
+            nil,
+            &hotKeyID
+        )
+
+        guard status == noErr else {
+            logger.error("Failed to read global hotkey event payload: status=\(status, privacy: .public)")
+            return
+        }
+
+        guard hotKeyID.signature == Self.hotKeySignature, hotKeyID.id == Self.hotKeyID else {
+            return
+        }
+
+        logger.info("Global unmount-all hotkey pressed")
+        Task { @MainActor [onUnmountAll] in
+            onUnmountAll()
+        }
+    }
+}

--- a/Ejectify/View/StatusBar.swift
+++ b/Ejectify/View/StatusBar.swift
@@ -25,4 +25,9 @@ final class StatusBar {
             statusBarButton.image?.isTemplate = true
         }
     }
+
+    /// Rebuilds the status menu to reflect current state.
+    func refreshMenu() {
+        (statusItem.menu as? StatusBarMenu)?.refreshMenu()
+    }
 }

--- a/Ejectify/View/StatusBarMenu.swift
+++ b/Ejectify/View/StatusBarMenu.swift
@@ -104,6 +104,11 @@ final class StatusBarMenu: NSMenu {
         updateMenu()
     }
 
+    /// Rebuilds the menu using the latest mounted volume snapshot.
+    func refreshMenu() {
+        refreshVolumesMenu()
+    }
+
     /// Returns a volume from cached `volumes` by matching a notification URL path.
     private func cachedVolume(from notification: Notification, urlKey: String) -> Volume? {
         guard let url = notification.userInfo?[urlKey] as? URL else {
@@ -139,8 +144,16 @@ final class StatusBarMenu: NSMenu {
 
     /// Builds the top "Actions" section.
     private func buildActionsMenu() {
-        let unmountAllItem = NSMenuItem(title: String(localized: "Unmount all"), action: #selector(unmountAllClicked(menuItem:)), keyEquivalent: "")
+        let isHotKeyRegistered = MainActor.assumeIsolated {
+            AppDelegate.shared.isUnmountAllHotKeyRegistered
+        }
+        let unmountAllItem = NSMenuItem(
+            title: String(localized: "Unmount all"),
+            action: #selector(unmountAllClicked(menuItem:)),
+            keyEquivalent: isHotKeyRegistered ? "u" : ""
+        )
         unmountAllItem.target = self
+        unmountAllItem.keyEquivalentModifierMask = isHotKeyRegistered ? [.control, .command] : []
         unmountAllItem.isEnabled = !volumes.isEmpty
         addItem(unmountAllItem)
     }
@@ -274,17 +287,9 @@ final class StatusBarMenu: NSMenu {
 
     /// Unmounts all currently enabled volumes from the menu action.
     @objc private func unmountAllClicked(menuItem _: NSMenuItem) {
-        let enabledVolumes = volumes.filter { $0.enabled }
-        logger.info("Manual unmount-all triggered: \(enabledVolumes.count, privacy: .public) enabled volumes")
-        for volume in enabledVolumes {
-            VolumeOperationRouter.shared.unmount(
-                volumeUUID: volume.id as NSUUID,
-                volumeName: volume.name,
-                bsdName: volume.bsdName,
-                force: Preference.forceUnmount
-            ) { _ in }
+        MainActor.assumeIsolated {
+            AppDelegate.shared.performManualUnmountAll()
         }
-        updateMenu()
     }
 
     /// Toggles automatic handling for a specific volume row.


### PR DESCRIPTION
## Summary
- add a Carbon-based global `Control-Command-U` hotkey for `Unmount all`
- centralize the manual unmount-all action in `AppDelegate` so the menu item and hotkey share the same behavior
- show the shortcut in the status bar menu only when the global hotkey registers successfully
- add `GlobalHotKeyController` to own hotkey registration, event handling, and logging

## Testing
- `xcodebuildmcp macos build --scheme Ejectify --project-path ./Ejectify.xcodeproj`