### PR TITLE
Repair stale privileged helper registration

### DIFF
--- a/Ejectify.xcodeproj/project.pbxproj
+++ b/Ejectify.xcodeproj/project.pbxproj
@@ -65,6 +65,10 @@
 		E8A1000A000000000000000A /* APFSEncryptedVolumeUnlockerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8A1000C000000000000000C /* APFSEncryptedVolumeUnlockerTests.swift */; };
 		E8A1000B000000000000000B /* VolumeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8A1000D000000000000000D /* VolumeTests.swift */; };
 		E8A1000F000000000000000F /* DiskArbitrationVolumeOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A100000000000000000053 /* DiskArbitrationVolumeOperator.swift */; };
+		F3A100010000000000000001 /* PrivilegedHelperLifecycleManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A100050000000000000005 /* PrivilegedHelperLifecycleManagerTests.swift */; };
+		F3A100020000000000000002 /* PrivilegedHelperLifecycleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E700A32F8A000100C0D001 /* PrivilegedHelperLifecycleManager.swift */; };
+		F3A100030000000000000003 /* PrivilegedHelperConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A100000000000000000066 /* PrivilegedHelperConfiguration.swift */; };
+		F3A100040000000000000004 /* SMAppService+StatusDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A100000000000000000054 /* SMAppService+StatusDescription.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -177,6 +181,7 @@
 		E8A100060000000000000006 /* EncryptedVolumePasswordPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptedVolumePasswordPrompt.swift; sourceTree = "<group>"; };
 		E8A1000C000000000000000C /* APFSEncryptedVolumeUnlockerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APFSEncryptedVolumeUnlockerTests.swift; sourceTree = "<group>"; };
 		E8A1000D000000000000000D /* VolumeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeTests.swift; sourceTree = "<group>"; };
+		F3A100050000000000000005 /* PrivilegedHelperLifecycleManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivilegedHelperLifecycleManagerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -332,6 +337,7 @@
 			children = (
 				E8A1000C000000000000000C /* APFSEncryptedVolumeUnlockerTests.swift */,
 				E7C700060000000000000006 /* LogTests.swift */,
+				F3A100050000000000000005 /* PrivilegedHelperLifecycleManagerTests.swift */,
 				E7C710040000000000000004 /* VolumeOperationOutcomePolicyTests.swift */,
 				E7C700070000000000000007 /* VolumeLogLabelFormatterTests.swift */,
 			);
@@ -593,6 +599,10 @@
 				E8A1000F000000000000000F /* DiskArbitrationVolumeOperator.swift in Sources */,
 				E7C710060000000000000006 /* DAReturn+StatusDescription.swift in Sources */,
 				E7C700030000000000000003 /* Log.swift in Sources */,
+				F3A100030000000000000003 /* PrivilegedHelperConfiguration.swift in Sources */,
+				F3A100020000000000000002 /* PrivilegedHelperLifecycleManager.swift in Sources */,
+				F3A100010000000000000001 /* PrivilegedHelperLifecycleManagerTests.swift in Sources */,
+				F3A100040000000000000004 /* SMAppService+StatusDescription.swift in Sources */,
 				E7C710050000000000000005 /* VolumeOperationOutcomePolicy.swift in Sources */,
 				E7C700040000000000000004 /* VolumeLogLabelFormatter.swift in Sources */,
 				E7C700010000000000000001 /* LogTests.swift in Sources */,

--- a/Ejectify/Helper/PrivilegedHelperLifecycleManager.swift
+++ b/Ejectify/Helper/PrivilegedHelperLifecycleManager.swift
@@ -56,6 +56,38 @@ final class PrivilegedHelperLifecycleManager: @unchecked Sendable {
         return isDaemonEnabled
     }
 
+    /// Re-registers an enabled launch daemon after unregistering its previous app-bundle association.
+    @discardableResult
+    func reregisterDaemon() async -> Bool {
+        let daemonService = self.daemonService
+
+        do {
+            try await Self.replaceDaemonRegistration(
+                unregister: {
+                    try await daemonService.unregister()
+                    Log.privilegedHelper.log("Privileged helper daemon unregistered before replacement registration")
+                },
+                register: {
+                    try daemonService.register()
+                    Log.privilegedHelper.log("Privileged helper daemon replacement registered; currentStatus=\(daemonService.status.statusDescription)")
+                }
+            )
+        } catch {
+            Log.privilegedHelper.error(error, message: "Privileged helper daemon replacement registration failed")
+        }
+
+        return isDaemonEnabled
+    }
+
+    /// Awaits `unregister` before invoking `register` for a replacement daemon registration.
+    static func replaceDaemonRegistration(
+        unregister: () async throws -> Void,
+        register: () throws -> Void
+    ) async throws {
+        try await unregister()
+        try register()
+    }
+
     /// Unregisters the launch daemon and returns whether privileged routing is disabled.
     @discardableResult
     func unregisterDaemon() -> Bool {

--- a/Ejectify/Helper/VolumeOperationRouter.swift
+++ b/Ejectify/Helper/VolumeOperationRouter.swift
@@ -380,7 +380,9 @@ final class VolumeOperationRouter: @unchecked Sendable {
         guard let proxy = helperProxy(
             for: connection,
             operationDescription: "startup ping",
-            onRoutingFailure: { _ in }
+            onRoutingFailure: { [weak self] _ in
+                self?.endStartupRoutingInitialization()
+            }
         ) else {
             endStartupRoutingInitialization()
             return
@@ -419,6 +421,32 @@ final class VolumeOperationRouter: @unchecked Sendable {
 
         initializeHelperRoutingFromStartupPing()
         return true
+    }
+
+    /// Repairs an enabled daemon registration that no longer provides a reachable helper.
+    @discardableResult
+    private func repairEnabledDaemonRegistration() async -> Bool {
+        Log.privilegedHelper.warning("Privileged helper daemon is enabled but unavailable; attempting daemon re-registration")
+
+        guard await PrivilegedHelperLifecycleManager.shared.reregisterDaemon() else {
+            let status = PrivilegedHelperLifecycleManager.shared.daemonStatus
+            invalidateHelperConnection()
+            setExecutionMode(.local, reason: "daemon re-registration requires user approval or failed: \(status.statusDescription)")
+            return false
+        }
+
+        initializeHelperRoutingFromStartupPing()
+        return true
+    }
+
+    /// Repairs a stale enabled registration or performs the ordinary privileged-execution request.
+    @discardableResult
+    func requestPrivilegedExecutionModeRepairingStaleRegistration() async -> Bool {
+        if isDaemonEnabled, !isUsingPrivilegedHelper, !isStartupRoutingInitializationActive {
+            return await repairEnabledDaemonRegistration()
+        }
+
+        return requestPrivilegedExecutionMode()
     }
 
     /// Attempts to register and enable privileged helper execution after an explicit user action.

--- a/Ejectify/View/StatusBarMenu.swift
+++ b/Ejectify/View/StatusBarMenu.swift
@@ -333,24 +333,25 @@ final class StatusBarMenu: NSMenu {
     @objc private func elevatedPermissionsClicked(menuItem: NSMenuItem) {
         let shouldEnable = toggledValue(for: menuItem.state)
         let operationRouter = VolumeOperationRouter.shared
-        let didSucceed: Bool
 
         if shouldEnable {
-            didSucceed = operationRouter.requestPrivilegedExecutionMode()
-            guard !didSucceed else {
-                updateMenu()
-                return
-            }
+            Task { @MainActor in
+                let didSucceed = await operationRouter.requestPrivilegedExecutionModeRepairingStaleRegistration()
+                guard !didSucceed else {
+                    updateMenu()
+                    return
+                }
 
-            showPermissionAlert(
-                messageText: String(localized: "Could not enable elevated permissions."),
-                informativeText: String(localized: "Check System Settings if Ejectify is enabled.")
-            )
-            updateMenu()
+                showPermissionAlert(
+                    messageText: String(localized: "Could not enable elevated permissions."),
+                    informativeText: String(localized: "Check System Settings if Ejectify is enabled.")
+                )
+                updateMenu()
+            }
             return
         }
 
-        didSucceed = operationRouter.disablePrivilegedExecutionMode()
+        let didSucceed = operationRouter.disablePrivilegedExecutionMode()
         guard didSucceed else {
             showPermissionAlert(
                 messageText: String(localized: "Could not disable elevated permissions.")

--- a/EjectifyTests/Helper/PrivilegedHelperLifecycleManagerTests.swift
+++ b/EjectifyTests/Helper/PrivilegedHelperLifecycleManagerTests.swift
@@ -1,0 +1,36 @@
+//
+//  PrivilegedHelperLifecycleManagerTests.swift
+//  EjectifyTests
+//
+//  Created by Codex on 06/08/2026.
+//
+
+import Testing
+
+/// Verifies the ordering required when replacing a privileged-helper registration.
+struct PrivilegedHelperLifecycleManagerTests {
+
+    /// Observable steps in a replacement-registration operation.
+    private enum Operation: Equatable {
+        case unregisterStarted
+        case unregisterCompleted
+        case register
+    }
+
+    @Test func replacementRegistrationAwaitsUnregistration() async throws {
+        var operations: [Operation] = []
+
+        try await PrivilegedHelperLifecycleManager.replaceDaemonRegistration(
+            unregister: {
+                operations.append(.unregisterStarted)
+                await Task.yield()
+                operations.append(.unregisterCompleted)
+            },
+            register: {
+                operations.append(.register)
+            }
+        )
+
+        #expect(operations == [.unregisterStarted, .unregisterCompleted, .register])
+    }
+}


### PR DESCRIPTION
## Summary

Follow Apple's standard SMAppService workflow for replacing a stale helper registration: await unregister completion before calling register. This repairs an enabled but unreachable helper without manipulating launchd directly.

Failed startup pings now also release their in-progress state so the explicit repair can run.

Apple documentation: https://developer.apple.com/documentation/servicemanagement/smappservice

## Verification

- 36 tests passed
- Release build succeeded
- Installed app passed strict code-signature verification